### PR TITLE
Fix front-matter crash on VS Code 1.121+ (metaData.split is not a function)

### DIFF
--- a/src/plugin/transform/badge-meta.ts
+++ b/src/plugin/transform/badge-meta.ts
@@ -22,7 +22,30 @@ export function transformBadgeMeta(state: StateCore): void {
     // Check if the current token is a front matter token
     if (tokens[i].type === TokenType.FRONT_MATTER) {
       const metaToken = tokens[i];
-      const metaData = metaToken.meta;
+
+      // The front_matter token is produced by the host markdown engine, whose
+      // shape for `token.meta` is not stable across VS Code versions:
+      //   - VS Code <= 1.120: `token.meta` is the raw front matter string.
+      //   - VS Code >= 1.121: `token.meta` is an object `{ content: string }`
+      //     (the engine started wrapping the raw text in 1.121).
+      // Reading it as a string unconditionally throws
+      // "metaData.split is not a function" on 1.121+, which breaks the entire
+      // markdown/parse and takes down the language service (issue #81).
+      // Normalize both shapes to the raw string, and skip safely if neither
+      // is present rather than throwing.
+      const rawMeta: unknown = metaToken.meta;
+      const metaData: string =
+        typeof rawMeta === "string"
+          ? rawMeta
+          : rawMeta != null &&
+            typeof (rawMeta as { content?: unknown }).content === "string"
+          ? (rawMeta as { content: string }).content
+          : "";
+
+      // No usable front matter text — skip badge processing for this token.
+      if (metaData === "") {
+        continue;
+      }
 
       // Split the meta data into lines
       const metaLines = metaData.split("\n");


### PR DESCRIPTION
Closes #81.

## Problem

After VS Code auto-updated to **1.121**, Adobe authors hit repeated language-service failures on any markdown file with front matter:

```
Request markdown/parse failed with message: metaData.split is not a function
```

Every dependent request failed — `foldingRange`, `documentLink`, `documentSymbol`, `codeAction` — because the throw happens inside VS Code's own markdown engine (our plugin is loaded via the `markdown.markdownItPlugins` contribution). The only mitigation was pinning to 1.120.

## Root cause

`src/plugin/transform/badge-meta.ts` read the `front_matter` token's `.meta` as a string and called `.split("\n")` on it. **VS Code 1.121 changed its bundled front-matter rule to wrap the raw text in an object** rather than passing the string directly:

| VS Code | `token.meta` |
|---|---|
| ≤ 1.120 | `"badge: label=…"` (string) |
| ≥ 1.121 | `{ content: "badge: label=…" }` (object) |

`.split` on the object → `metaData.split is not a function` → the whole parse throws.

(Confirmed by reading the shipped engine: `dist/extension.js` in `markdown-language-features` now does `let p = { content: _ }; d.meta = p;`.)

## Fix

Normalize both shapes to the raw string, and skip safely (don't throw) if neither is present — a parse error here breaks the language service for *all* consumers, so failing soft is correct:

```ts
const rawMeta: unknown = metaToken.meta;
const metaData: string =
  typeof rawMeta === "string"
    ? rawMeta
    : rawMeta != null && typeof (rawMeta as { content?: unknown }).content === "string"
    ? (rawMeta as { content: string }).content
    : "";
if (metaData === "") continue;
```

This is also future-proofed: our code no longer couples to VS Code's internal token shape, and an unexpected shape degrades to "badges don't render" rather than "parser crashes."

## Verification

Ran the **built** plugin against a front-matter document carrying a `badge:` line, emulating VS Code's real front-matter rule in both shapes:

| | meta=string (≤1.120) | meta=object (≥1.121) | malformed (null/undefined/{}/number) |
|---|---|---|---|
| **Before** | ✅ no throw | ❌ `metaData.split is not a function` | — |
| **After** | ✅ badge renders | ✅ badge renders | ✅ no throw (fail-soft) |

The pre-fix code reproduces the reporter's exact error on the object shape; the fix renders badges correctly on both versions.

## Follow-up (not in this PR)

A permanent automated regression test is gated on the test suite being runnable again (#78). Note: the existing golden-file harness uses a bare `new MarkdownIt()` with **no** front-matter plugin, so it never produces a `front_matter` token — the regression test must be a unit test that emits the token in **both** meta shapes (string + object), mirroring the verification used here. Tracked via #78 / #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)