### PR TITLE
Release 2.1.5: package front-matter crash fix for Marketplace

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Adobe Markdown Authoring extension for Visual Studio Code",
   "description": "All-in-one Adobe Flavored Markdown document authoring extension for Visual Studio Code.",
   "publisher": "AdobeExl",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "engines": {
     "vscode": "^1.74.0"
   },
@@ -23,9 +23,6 @@
     "onLanguage:markdown"
   ],
   "main": "./dist/extension.js",
-  "files": [
-    "assets/**/*"
-  ],
   "contributes": {
     "markdown.previewStyles": [
       "./assets/styles/spectrum.css",


### PR DESCRIPTION
## What

Bumps the extension version **2.1.4 → 2.1.5** so the patched build for the VS Code 1.121+ front-matter crash ([#81](https://github.com/AdobeDocs/adobe-markdown-authoring/issues/81), fixed in [#82](https://github.com/AdobeDocs/adobe-markdown-authoring/pull/82)) can be published to the Marketplace — which rejects re-uploads of an existing version number.

The packaged `.vsix` is already published as a GitHub Release for manual upload to the AdobeExl listing: https://github.com/AdobeDocs/adobe-markdown-authoring/releases/tag/v2.1.5

## Changes

- `version`: `2.1.4` → `2.1.5`
- Remove the npm `files: ["assets/**"]` allowlist from `package.json`. Current `@vscode/vsce` refuses to package when both `.vscodeignore` and a `files` property are present; `.vscodeignore` is the correct and complete strategy for the vsix. The `files` entry was wrong for the extension anyway — taken literally it would exclude the built `dist/` output.

## Notes

- No source/behavior changes — the actual front-matter fix already landed on `main` via #82. This PR only carries the release metadata needed to ship it.
- Verified: the `dist/extension.js` bundled into the 2.1.5 `.vsix` contains the front-matter normalization (and the old unguarded `token.meta.split()` call is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)